### PR TITLE
Updated patient_number to patient_id

### DIFF
--- a/data/generic-anc/base/app-settings.json
+++ b/data/generic-anc/base/app-settings.json
@@ -522,7 +522,7 @@
                             "locale": "sw"
                         },
                         {
-                            "content": "Aucun patient a été trouvé avec le numéro d'identification '{{patient_number}}'. Vérifier le code d'identification et réessayer",
+                            "content": "Aucun patient a été trouvé avec le numéro d'identification '{{patient_id}}'. Vérifier le code d'identification et réessayer",
                             "locale": "fr"
                         },
                         {


### PR DESCRIPTION
caught an error in the French translation of the error message for
incorrect patient ID.